### PR TITLE
latest release was using this.serial_Id

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function RelativeHumidityAccessory(log, config) {
   this.name = config["name"];
   this.url = config['url'];
   this.topic = config['topic'];
+  this.client_Id = 'mqttjs_' + Math.random().toString(16).substr(2, 8);
   this.options = {
     keepalive: 10,
     clientId: this.client_Id,


### PR DESCRIPTION
latest release was using this.serial_Id, however, not setting it anywhere.
I suspect this is copy-paste error from homebridge-mqtt-temperature :)

the initialization of this.serial_Id was lost, here is PR to fix it (as in https://github.com/mcchots/homebridge-mqtt-temperature/blob/master/index.js#L19)